### PR TITLE
Removing hardcoded amd64 from build

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -2,10 +2,12 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 ARG GOVERSION=1.11.1
 WORKDIR /go/src/sigs.k8s.io/sig-storage-local-static-provisioner
 COPY . .
-RUN CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o _output/linux/amd64/local-volume-provisioner ./cmd/local-volume-provisioner
+RUN CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o _output/linux/$(go env GOARCH)/local-volume-provisioner ./cmd/local-volume-provisioner; \
+    mkdir -p /tmp/build; \
+    cp /go/src/sigs.k8s.io/sig-storage-local-static-provisioner/_output/linux/$(go env GOARCH)/local-volume-provisioner /tmp/build/;
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/sigs.k8s.io/sig-storage-local-static-provisioner/_output/linux/amd64/local-volume-provisioner /local-provisioner
+COPY --from=builder /tmp/build/local-volume-provisioner /local-provisioner
 RUN yum install -y e2fsprogs xfsprogs && yum clean all && rm -rf /var/cache/yum
 ADD deployment/docker/scripts /scripts
 ENTRYPOINT ["/local-provisioner"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -2,10 +2,12 @@ FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.11 AS builder
 ARG GOVERSION=1.11.1
 WORKDIR /go/src/sigs.k8s.io/sig-storage-local-static-provisioner
 COPY . .
-RUN CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o _output/linux/amd64/local-volume-provisioner ./cmd/local-volume-provisioner
+RUN CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o _output/linux/$(go env GOARCH)/local-volume-provisioner ./cmd/local-volume-provisioner; \
+    mkdir -p /tmp/build; \
+    cp /go/src/sigs.k8s.io/sig-storage-local-static-provisioner/_output/linux/$(go env GOARCH)/local-volume-provisioner /tmp/build/;
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/sigs.k8s.io/sig-storage-local-static-provisioner/_output/linux/amd64/local-volume-provisioner /local-provisioner
+COPY --from=builder /tmp/build/local-volume-provisioner /local-provisioner
 RUN yum install -y e2fsprogs xfsprogs && yum clean all && rm -rf /var/cache/yum
 ADD deployment/docker/scripts /scripts
 ENTRYPOINT ["/local-provisioner"]


### PR DESCRIPTION
This PR removes the hardcoded `amd64` and replaces it with generic GOARCH variable so that the build can be done on other archs as well.