### PR TITLE
Updating local-storage-static-provisioner builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/sigs.k8s.io/sig-storage-local-static-provisioner
 COPY . .
 RUN CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o _output/cmd/local-volume-provisioner ./cmd/local-volume-provisioner
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 COPY --from=builder /go/src/sigs.k8s.io/sig-storage-local-static-provisioner/_output/cmd/local-volume-provisioner /local-provisioner
 RUN yum install -y e2fsprogs xfsprogs && yum clean all && rm -rf /var/cache/yum
 ADD deployment/docker/scripts /scripts


### PR DESCRIPTION
Updating local-storage-static-provisioner builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/local-storage-static-provisioner.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.