### PR TITLE
Bug 2032924: prevent cleaning released volumes more than once

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -28,13 +28,17 @@ import (
 // It is periodically updated by the Populator.
 // The Deleter and Discoverer use the VolumeCache to check on created PVs
 type VolumeCache struct {
-	mutex sync.Mutex
-	pvs   map[string]*v1.PersistentVolume
+	mutex   sync.Mutex
+	pvs     map[string]*v1.PersistentVolume
+	cleaned map[string]bool
 }
 
 // NewVolumeCache creates a new PV cache object for storing PVs created by this provisioner.
 func NewVolumeCache() *VolumeCache {
-	return &VolumeCache{pvs: map[string]*v1.PersistentVolume{}}
+	return &VolumeCache{
+		pvs:     map[string]*v1.PersistentVolume{},
+		cleaned: map[string]bool{},
+	}
 }
 
 // GetPV returns the PV object given the PV name
@@ -52,6 +56,7 @@ func (cache *VolumeCache) AddPV(pv *v1.PersistentVolume) {
 	defer cache.mutex.Unlock()
 
 	cache.pvs[pv.Name] = pv
+	cache.cleaned[pv.Name] = false
 	klog.Infof("Added pv %q to cache", pv.Name)
 }
 
@@ -70,6 +75,7 @@ func (cache *VolumeCache) DeletePV(pvName string) {
 	defer cache.mutex.Unlock()
 
 	delete(cache.pvs, pvName)
+	delete(cache.cleaned, pvName)
 	klog.Infof("Deleted pv %q from cache", pvName)
 }
 
@@ -83,4 +89,23 @@ func (cache *VolumeCache) ListPVs() []*v1.PersistentVolume {
 		pvs = append(pvs, pv)
 	}
 	return pvs
+}
+
+// CleanPV marks the PV object as cleaned in the cache
+func (cache *VolumeCache) CleanPV(pv *v1.PersistentVolume) {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	cache.cleaned[pv.Name] = true
+	klog.Infof("Marked pv %q as cleaned in the cache", pv.Name)
+}
+
+// SuccessfullyCleanedPV returns true if the PV was already cleaned once
+// since the cache entry was created, or if the cache entry no longer exists.
+func (cache *VolumeCache) SuccessfullyCleanedPV(pv *v1.PersistentVolume) bool {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	cleaned, exists := cache.cleaned[pv.Name]
+	return !exists || cleaned
 }

--- a/pkg/deleter/deleter.go
+++ b/pkg/deleter/deleter.go
@@ -72,6 +72,9 @@ func (d *Deleter) DeletePVs() {
 		if pv.Status.Phase != v1.VolumeReleased {
 			continue
 		}
+		if d.Cache.SuccessfullyCleanedPV(pv) {
+			continue
+		}
 		name := pv.Name
 		switch pv.Spec.PersistentVolumeReclaimPolicy {
 		case v1.PersistentVolumeReclaimRetain:
@@ -162,6 +165,7 @@ func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
 	switch state {
 	case CSSucceeded:
 		// Found a completed cleaning entry
+		d.Cache.CleanPV(pv)
 		klog.Infof("Deleting pv %s after successful cleanup", pv.Name)
 		if err = d.APIUtil.DeletePV(pv.Name); err != nil {
 			if !errors.IsNotFound(err) {


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a small time window between the deleter finding a successfully
completed cleanup job and the cache entry being removed in which
DeletePVs() may be called again. If this happens, then a second cleanup
job may be started before the cache entry is removed. This fix prevents
starting another cleanup job for a cache entry that has already been
cleaned successfully.

**Which issue(s) this PR fixes**:
Carry patch to address https://bugzilla.redhat.com/show_bug.cgi?id=2032924

**Special notes for your reviewer**:
/cc @openshift/storage 