### PR TITLE
OCPBUGS-2450: do not flag PV as cleaned in cache too early

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -100,6 +100,15 @@ func (cache *VolumeCache) CleanPV(pv *v1.PersistentVolume) {
 	klog.Infof("Marked pv %q as cleaned in the cache", pv.Name)
 }
 
+// UncleanPV marks the PV object as not cleaned in the cache
+func (cache *VolumeCache) UncleanPV(pv *v1.PersistentVolume) {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	cache.cleaned[pv.Name] = false
+	klog.Infof("Marked pv %q as not clean in the cache", pv.Name)
+}
+
 // SuccessfullyCleanedPV returns true if the PV was already cleaned once
 // since the cache entry was created, or if the cache entry no longer exists.
 func (cache *VolumeCache) SuccessfullyCleanedPV(pv *v1.PersistentVolume) bool {

--- a/pkg/deleter/deleter.go
+++ b/pkg/deleter/deleter.go
@@ -169,6 +169,8 @@ func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
 		klog.Infof("Deleting pv %s after successful cleanup", pv.Name)
 		if err = d.APIUtil.DeletePV(pv.Name); err != nil {
 			if !errors.IsNotFound(err) {
+				// PV failed to delete in API server, flag the PV as not cleaned so next reconcile attempts the deletion again.
+				d.Cache.UncleanPV(pv)
 				d.RuntimeConfig.Recorder.Eventf(pv, v1.EventTypeWarning, common.EventVolumeFailedDelete,
 					err.Error())
 				return fmt.Errorf("Error deleting PV %q: %v", pv.Name, err.Error())


### PR DESCRIPTION
We were updating cache too early and flagged PV as cleaned before calling API server which can fail, and if it fails the deleter reconcile loop will never attempt the PV deletion again because it's already flagged as cleaned in the cache. This resulted in PVs getting stuck in "Released" state and never transitioning to "Available".

We should recover from the failure by flagging the PV as not cleaned in cache if the API request fails so that next reconcile will attempt the deletion again.